### PR TITLE
Jlamson/mac and test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ cython_debug/
 
 # Project specific
 **stats**.html
+test_data/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,167 @@
-stats.html
-__pycache__/app.cpython-311.pyc
-__pycache__/data_parser.cpython-311.pyc
-__pycache__/views.cpython-311.pyc
-assets/__pycache__/data_parser.cpython-311.pyc
-stats_*.html
+# From https://github.com/github/gitignore/blob/main/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Project specific
+**stats**.html

--- a/assets/data_parser.py
+++ b/assets/data_parser.py
@@ -111,7 +111,7 @@ def reload_file():
 			rankedTies = data['ServerState']['Account']['TiesInPlaytestEnvironment']
 
 		global standing
-		if 'LeaderboardLog' not in data['ServerState'] or 'InfiniteLeaderboardDetails' not in data['ServerState']['LeaderboardLog']:
+		if 'LeaderboardLog' not in data['ServerState'] or 'InfiniteLeaderboardStanding' not in data['ServerState']['LeaderboardLog']:
 			standing = 'N.A.'
 		else:
 			standing = "#" + str(data['ServerState']['LeaderboardLog']['InfiniteLeaderboardStanding'])

--- a/assets/data_parser.py
+++ b/assets/data_parser.py
@@ -1,21 +1,7 @@
 import json
 import os
 import datetime
-import platform
-from os import environ
-
-is_android = 'ANDROID_STORAGE' in environ
-
-def isSystemWindows():
-    return platform.system() == 'Windows'
-
-def isSystemLinux():
-    return platform.system() == 'Linux'
-
-def isSystemMobile():
-    if platform.system() == 'Linux' and is_android:
-        return True
-    return False
+import assets.file_config as file_config
 
 snapId = ''
 playerName = ''
@@ -58,28 +44,9 @@ cardBacksOwned = 0
 collectionLvl = 0
 cardUnlockHistory = {}
 
-profileFilePath = '~/AppData/Locallow/Second Dinner/SNAP/Standalone/States/nvprod/ProfileState.json'
-if isSystemLinux():
-	profileFilePath = '~/.steam/steam/steamapps/compatdata/1997040/pfx/drive_c/users/steamuser/AppData/LocalLow/Second Dinner/SNAP/Standalone/States/nvprod/ProfileState.json'
-if isSystemMobile():
-	profileFilePath = '/sdcard/Android/data/com.nvsgames.snap/files/Standalone/States/nvprod/ProfileState.json'
-profilePath = os.path.expanduser(profileFilePath)
-
-shopFilePath = '~/AppData/Locallow/Second Dinner/SNAP/Standalone/States/nvprod/ShopState.json'
-if isSystemLinux():
-	shopFilePath = '~/.steam/steam/steamapps/compatdata/1997040/pfx/drive_c/users/steamuser/AppData/LocalLow/Second Dinner/SNAP/Standalone/States/nvprod/ShopState.json'
-if isSystemMobile():
-	shopFilePath = '/sdcard/Android/data/com.nvsgames.snap/files/Standalone/States/nvprod/ShopState.json'
-shopPath = os.path.expanduser(shopFilePath)
-
-collectionFilePath = '~/AppData/Locallow/Second Dinner/SNAP/Standalone/States/nvprod/CollectionState.json'
-if isSystemLinux():
-	collectionFilePath = '~/.steam/steam/steamapps/compatdata/1997040/pfx/drive_c/users/steamuser/AppData/LocalLow/Second Dinner/SNAP/Standalone/States/nvprod/CollectionState.json'
-if isSystemMobile():
-	collectionFilePath = '/sdcard/Android/data/com.nvsgames.snap/files/Standalone/States/nvprod/CollectionState.json'
-collectionPath = os.path.expanduser(collectionFilePath)
-
 def reload_file():
+	shopPath = file_config.getShopPath()
+	print(f"shopPath: {shopPath}")
 	with open(shopPath, encoding="utf-8-sig") as shop_json_file:
 		data = json.load(shop_json_file)
 
@@ -89,6 +56,8 @@ def reload_file():
 		else:
 			battlePassesBought = data['ServerState']['Account']['ProductPurchaseCount']['BattlePassPremiumBasic']
 
+	profilePath = file_config.getProfilePath()
+	print(f"profilePath: {profilePath}")
 	with open(profilePath, encoding="utf-8-sig") as profile_json_file:
 		data = json.load(profile_json_file)
 
@@ -206,6 +175,8 @@ def reload_file():
 		global totalCollectorsTokensSpent
 		totalCollectorsTokensSpent = data['ServerState']['Wallet']['_collectorsTokensCurrency']['SpentAmount']
 
+	collectionPath = file_config.getCollectionPath()
+	print(f"collectionPath: {collectionPath}")
 	with open(collectionPath, encoding="utf-8-sig") as collection_json_file:
 		data = json.load(collection_json_file)
 
@@ -282,7 +253,7 @@ def get_rankedCurrentWinStreak():
 	return winstreakAddPlusSign(rankedCurrentWinStreak)
 
 def get_timeUpdated():
-	timestamp = os.path.getmtime(os.path.expanduser(profileFilePath))
+	timestamp = os.path.getmtime(os.path.expanduser(file_config.getProfilePath()))
 	return datetime.datetime.fromtimestamp(timestamp).strftime('%B %d %I:%M %p')
 
 def get_timeStarted():

--- a/assets/file_config.py
+++ b/assets/file_config.py
@@ -46,7 +46,6 @@ Defaults:
 # ---- CLI Argument Parsing ----
 
 args = sys.argv[1:]
-print("\n".join(args))
 
 def getArgs():
     return args

--- a/assets/file_config.py
+++ b/assets/file_config.py
@@ -1,0 +1,118 @@
+from os import environ
+import os
+import platform
+import sys
+
+# ---- Constants ----
+
+ARG_HELP_SHORT = '-h'
+ARG_HELP_LONG = '--help'
+
+ARG_TEST = '-t'
+ARG_COLLECTION = '-c'
+ARG_PROFILE = '-p'
+ARG_SHOP = '-s'
+
+PATH_WINDOWS = '~/AppData/Locallow/Second Dinner/SNAP/Standalone/States/nvprod/'
+PATH_LINUX = '~/.steam/steam/steamapps/compatdata/1997040/pfx/drive_c/users/steamuser/AppData/LocalLow/Second Dinner/SNAP/Standalone/States/nvprod/'
+PATH_MOBILE = '/sdcard/Android/data/com.nvsgames.snap/files/Standalone/States/nvprod/'
+PATH_TEST = './test_data/'
+
+FILE_COLLECTION = 'CollectionState.json'
+FILE_PROFILE = 'ProfileState.json'
+FILE_SHOP = 'ShopState.json'
+
+USAGE = f"""
+Usage: python3 generate_file.py [-OPTIONS]
+
+Arguments:
+    {ARG_HELP_SHORT}, {ARG_HELP_LONG}: Display this help message.
+    {ARG_TEST}: Run the script in test mode.
+        If this flag is included, the script will ignore the current
+        system and search for all files in the `{PATH_TEST}` directory.
+    {ARG_COLLECTION}: The `{FILE_COLLECTION}` file location
+    {ARG_PROFILE}: The `{FILE_PROFILE}` file location
+    {ARG_SHOP}: The `{FILE_SHOP}` file location
+    
+Defaults:
+    If no arguments are provided, the script will search for the files
+    in the following directories:
+        - Windows: {PATH_WINDOWS}
+        - Linux: {PATH_LINUX}
+        - Mobile: {PATH_MOBILE}
+        - Mac (AKA Darwin) or unknown: {PATH_TEST}
+"""
+
+# ---- CLI Argument Parsing ----
+
+args = sys.argv[1:]
+print("\n".join(args))
+
+def getArgs():
+    return args
+
+def isTest():
+    return ARG_TEST in args
+
+def isHelp():
+    return ARG_HELP_SHORT in args or ARG_HELP_LONG in args
+
+def getArgFilePath(arg):
+    if arg not in args:
+        return None
+
+    index = args.index(arg)
+    filePath = args[index + 1]
+    if not filePath or not filePath.endswith('.json'):
+        print(USAGE)
+        raise FileNotFoundError(f"File path not found: {filePath}")
+    else:
+        return filePath
+
+# ---- System Detection ----
+
+is_android = 'ANDROID_STORAGE' in environ
+
+def isSystemWindows():
+    return platform.system() == 'Windows'
+
+def isSystemLinux():
+    return platform.system() == 'Linux'
+
+def isSystemMac():
+    return platform.system() == 'Darwin'
+
+def isSystemMobile():
+    if platform.system() == 'Linux' and is_android:
+        return True
+    return False
+
+# file resolution
+
+def getFilePath(arg, fileName):
+    path = ""
+    argPath = getArgFilePath(arg)
+    if argPath is not None:
+        path = argPath
+    elif isSystemWindows():
+        path = PATH_WINDOWS + fileName
+    elif isSystemLinux():
+        path = PATH_LINUX + fileName
+    elif isSystemMobile():
+        path = PATH_MOBILE + fileName
+    elif isTest() or isSystemMac():
+        path = PATH_TEST + fileName
+    else:
+        print(f"Unknown system, and no path path defined for {fileName}")
+        path = None
+    
+    return os.path.expanduser(path)
+
+def getProfilePath():
+    return getFilePath(ARG_PROFILE, FILE_PROFILE)
+
+def getShopPath():
+    return getFilePath(ARG_SHOP, FILE_SHOP)
+
+def getCollectionPath():
+    return getFilePath(ARG_COLLECTION, FILE_COLLECTION)

--- a/generate_file.py
+++ b/generate_file.py
@@ -64,6 +64,6 @@ with open("assets/template.html", encoding="utf-8-sig") as template_file:
         generated_file.write(content)
         
         if data_parser.isSystemWindows() or data_parser.isSystemLinux():
-           webbrowser.open_new_tab(fileNameToCreate)
+            webbrowser.open_new_tab(fileNameToCreate)
         if data_parser.isSystemMobile():
             print("File stats.html generated in the project folder. Open it manually in your browser!")

--- a/generate_file.py
+++ b/generate_file.py
@@ -1,9 +1,15 @@
+import os
 import webbrowser
 import assets.data_parser as data_parser
+import assets.file_config as file_config
 from datetime import datetime 
 
 content = ""
 screenWidthPrct = ''
+
+if file_config.isHelp():
+    print(file_config.USAGE)
+    exit()
 
 def addPlayerData(template_file):
     global content
@@ -50,9 +56,9 @@ def addPlayerData(template_file):
     content = content.replace("{{ cardUnlockHistory }}", str(data_parser.get_CardUnlockHistory()))
     content = content.replace("{{ screenWidthPrct }}", screenWidthPrct)
 
-if data_parser.isSystemWindows() or data_parser.isSystemLinux():
+if file_config.isSystemWindows() or file_config.isSystemLinux() or file_config.isSystemMac():
     screenWidthPrct = '70%'
-if data_parser.isSystemMobile():
+elif file_config.isSystemMobile():
     screenWidthPrct = '95%'
 
 fileNameToCreate = "stats_" + datetime.now().strftime("%d-%B-%Y-%H%M%S") + ".html"
@@ -63,7 +69,7 @@ with open("assets/template.html", encoding="utf-8-sig") as template_file:
         
         generated_file.write(content)
         
-        if data_parser.isSystemWindows() or data_parser.isSystemLinux():
-            webbrowser.open_new_tab(fileNameToCreate)
-        if data_parser.isSystemMobile():
-            print("File stats.html generated in the project folder. Open it manually in your browser!")
+        if file_config.isSystemWindows() or file_config.isSystemLinux() or file_config.isSystemMac():
+            webbrowser.open_new_tab(f"file://{os.path.abspath(fileNameToCreate)}")
+        if file_config.isSystemMobile():
+            print(f"File stats_date.html generated in the project folder. Open it manually in your browser!")


### PR DESCRIPTION
# Merge #4 first, this (currently) depends on that. 

This change got away from me a bit. It started as a desire to write python code on mac instead of windows, and it kinda blossomed into a much bigger refactor & feature set. 

Currently, i've marked this as a draft. the test mode & direct file paths work great, but I need to test on Windows (just need to pull & run) and linux/android (which I can do, just need a day or two)

## Details

[Add CLI arguments. Add Mac support (kinda). Add test mode](https://github.com/sergiodias25/Snap_Player_Stats/commit/0795881fc23c9a97f5acb3b959a16240500826da) 

* Move all configuration related code & constants into `assets/file_config`. I wanted to consolidate all the system level stuff alongside the argument based stuff.
    * Add support for multiple arguments, including help, a test mode, and declaration of specific paths to each file.
    * Add some basic error handling & usage documentation
    * Add system check for Macs (aka Darwin)
    * Move a bunch of stuff into constants
* Add test mode, which builds HTML against copy-pasted files. I added this initially because I like to write code on my mac (but game on windows). So I just uploaded my files to google drive, pulled them down onto the mac. It was nice, so then I got into the whole CLI thing and went overboard.
    * Update .gitignore to NOT track test_data, since it can have sensitive IDs

## Testing

### Mac - `-t` - file arguments

https://github.com/sergiodias25/Snap_Player_Stats/assets/799143/54eeb6fd-d439-4826-a740-53376e5f49a7
